### PR TITLE
Add initial pager implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/angles-n-daemons/popsql
+
+require github.com/matryer/is v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
+github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=

--- a/internal/backend/pager/pager.go
+++ b/internal/backend/pager/pager.go
@@ -1,0 +1,65 @@
+package pager
+
+import "fmt"
+
+const (
+	RESERVED_HEADER_PAGE_COUNT = 1
+)
+
+type file interface {
+	Read(int) ([]byte, error)
+	Write(int, []byte) error
+	Size() (int, error)
+}
+
+/*
+	Pager manages the database pages for access by the BTree
+
+	Properties
+	 - pageSize:      the number of bytes in each data page
+	 - fs:            file system operator used for reading and writing to the db
+	 - freelistIndex: the page number where the freelist starts
+
+	 The database has the following pages:
+
+	 Header:     Metadata about the database
+	 TablePages: Data pages for the database
+	 Freelist:   Unused pages to be allocated
+*/
+type Pager struct {
+	pageSize      int
+	fs            file
+	freelistIndex int
+}
+
+/*
+	Get retrieves the data page at offset i after the header
+*/
+func (p *Pager) Get(int i) ([]byte, error) {
+	if i < 1 || i > p.freelistIndex {
+		return nil, fmt.Errorf(
+			"cannot read page %d, index must be between 1 and %d",
+			i,
+			p.freelistIndex,
+		)
+	}
+
+	offset = RESERVED_HEADER_PAGE_COUNT * i * pageSize
+	return p.fs.Read(offset)
+}
+
+/*
+	Set puts a data page at offset i with the bytes in content
+*/
+func (p *Pager) Set(pageNumber int, content []byte) error {
+	if pageNumber < 1 || pageNumber > p.freelistIndex {
+		return nil, fmt.Errorf(
+			"cannot write page %d, index must be between 1 and %d",
+			pageNumber,
+			p.freelistIndex,
+		)
+	}
+
+	offset = RESERVED_HEADER_PAGE_COUNT * pageNumber * pageSize
+	return p.fs.Write(offset, content)
+}

--- a/internal/backend/pager/pager.go
+++ b/internal/backend/pager/pager.go
@@ -31,29 +31,29 @@ type Pager struct {
 }
 
 /*
-	Get retrieves the data page at offset i after the header
+	Get retrieves the data page at the offset after the header
 */
-func (p *Pager) Get(i int) ([]byte, error) {
-	if i < 0 || i >= p.freelistIndex {
+func (p *Pager) GetPage(offset int) ([]byte, error) {
+	if offset < 0 || offset >= p.freelistIndex {
 		return nil, fmt.Errorf(
 			"cannot read page %d, index must be between 0 and %d",
-			i,
+			offset,
 			p.freelistIndex,
 		)
 	}
 
-	offset := (i * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
-	return p.fs.Read(offset, p.pageSize)
+	offsetBytes := (offset * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
+	return p.fs.Read(offsetBytes, p.pageSize)
 }
 
 /*
-	Set puts a data page at offset i with the bytes in content
+	Set puts a data page at the offset with the bytes in content
 */
-func (p *Pager) Set(i int, content []byte) error {
-	if i < 0 || i >= p.freelistIndex {
+func (p *Pager) SetPage(offset int, content []byte) error {
+	if offset < 0 || offset >= p.freelistIndex {
 		return fmt.Errorf(
 			"cannot write page %d, index must be between 0 and %d",
-			i,
+			offset,
 			p.freelistIndex,
 		)
 	}
@@ -66,6 +66,6 @@ func (p *Pager) Set(i int, content []byte) error {
 		)
 	}
 
-	offset := (i * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
-	return p.fs.Write(offset, content)
+	offsetBytes := (offset * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
+	return p.fs.Write(offsetBytes, content)
 }

--- a/internal/backend/pager/pager.go
+++ b/internal/backend/pager/pager.go
@@ -7,15 +7,13 @@ const (
 )
 
 type file interface {
-	Read(int) ([]byte, error)
+	Read(int, int) ([]byte, error)
 	Write(int, []byte) error
-	Size() (int, error)
 }
 
 /*
 	Pager manages the database pages for access by the BTree
-
-	Properties
+Properties
 	 - pageSize:      the number of bytes in each data page
 	 - fs:            file system operator used for reading and writing to the db
 	 - freelistIndex: the page number where the freelist starts
@@ -35,31 +33,39 @@ type Pager struct {
 /*
 	Get retrieves the data page at offset i after the header
 */
-func (p *Pager) Get(int i) ([]byte, error) {
-	if i < 1 || i > p.freelistIndex {
+func (p *Pager) Get(i int) ([]byte, error) {
+	if i < 0 || i >= p.freelistIndex {
 		return nil, fmt.Errorf(
-			"cannot read page %d, index must be between 1 and %d",
+			"cannot read page %d, index must be between 0 and %d",
 			i,
 			p.freelistIndex,
 		)
 	}
 
-	offset = RESERVED_HEADER_PAGE_COUNT * i * pageSize
-	return p.fs.Read(offset)
+	offset := (i * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
+	return p.fs.Read(offset, p.pageSize)
 }
 
 /*
 	Set puts a data page at offset i with the bytes in content
 */
-func (p *Pager) Set(pageNumber int, content []byte) error {
-	if pageNumber < 1 || pageNumber > p.freelistIndex {
-		return nil, fmt.Errorf(
-			"cannot write page %d, index must be between 1 and %d",
-			pageNumber,
+func (p *Pager) Set(i int, content []byte) error {
+	if i < 0 || i >= p.freelistIndex {
+		return fmt.Errorf(
+			"cannot write page %d, index must be between 0 and %d",
+			i,
 			p.freelistIndex,
 		)
 	}
 
-	offset = RESERVED_HEADER_PAGE_COUNT * pageNumber * pageSize
+	if len(content) != p.pageSize {
+		return fmt.Errorf(
+			"content length %d larger than pagesize %d",
+			len(content),
+			p.pageSize,
+		)
+	}
+
+	offset := (i * p.pageSize) + (RESERVED_HEADER_PAGE_COUNT * p.pageSize)
 	return p.fs.Write(offset, content)
 }

--- a/internal/backend/pager/pager_test.go
+++ b/internal/backend/pager/pager_test.go
@@ -95,7 +95,7 @@ func TestPagerGet(t *testing.T) {
 				err:     test.fsError,
 			}
 
-			output, err := pager.Get(test.pageNumber)
+			output, err := pager.GetPage(test.pageNumber)
 			if test.returnsError {
 				is.True(err != nil)
 			} else {
@@ -139,6 +139,7 @@ func TestPagerSet(t *testing.T) {
 			name:         "write second page with fs error",
 			pageNumber:   2,
 			fsError:      errors.New("error"),
+			content:      []byte("cd"),
 			returnsError: true,
 		},
 		{
@@ -184,7 +185,7 @@ func TestPagerSet(t *testing.T) {
 			}
 			pager.fs = m
 
-			err := pager.Set(test.pageNumber, test.content)
+			err := pager.SetPage(test.pageNumber, test.content)
 			if test.returnsError {
 				is.True(err != nil)
 			} else {

--- a/internal/backend/pager/pager_test.go
+++ b/internal/backend/pager/pager_test.go
@@ -1,50 +1,200 @@
 package pager
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/matryer/is"
+)
 
 type mockFile struct {
 	index   int
-	content []bytes
+	content []byte
 	err     error
 }
 
-func (m mockFile) Read(int) ([]byte, error) {
-	return m.content, m.err
+func (m *mockFile) Read(i int, length int) ([]byte, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.content[i : i+length], nil
 }
-func (m mockFile) Write(int, []content) error {
+
+func (m *mockFile) Write(i int, content []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	m.content = []byte(
+		string(m.content[:i]) + string(content) + string(m.content[i+len(content):]),
+	)
 	return m.err
 
-}
-func (m mockFile) Size() (int, error) {
-	return m.size, m.err
 }
 
 const (
 	testPageSize = 2
-	alphabet     = "abcdefghijklmnopqrstuvwxyz"
+	numbers      = "0123456789"
 )
 
 func TestPagerGet(t *testing.T) {
+	is := is.New(t)
+
 	tests := []struct {
-		pageNumber int
-		expected   []byte
-		fsErr      error
-		errors     bool
+		name         string
+		pageNumber   int
+		expected     []byte
+		fsError      error
+		returnsError bool
 	}{
-		{0, []byte("cd"), nil, false},
+		{
+			name:       "read zeroth page",
+			pageNumber: 0,
+			expected:   []byte("23"),
+		},
+		{
+			name:       "read second page",
+			pageNumber: 2,
+			expected:   []byte("67"),
+		},
+
+		// errors
+		{
+			name:         "read second page with fs error",
+			pageNumber:   2,
+			fsError:      errors.New("error"),
+			returnsError: true,
+		},
+		{
+			name:         "read negative page",
+			pageNumber:   -2,
+			returnsError: true,
+		},
+		{
+			name:         "read past freelist",
+			pageNumber:   4,
+			returnsError: true,
+		},
+		{
+			name:         "read page at freelist start",
+			pageNumber:   3,
+			returnsError: true,
+		},
 	}
 
 	pager := Pager{
-		pageSize: 2,
+		pageSize:      2,
+		freelistIndex: 3,
 	}
 
-	for _, test := tests {
-		// set the fs on the pager
-		pager.fs = mockFile{
-			content: []byte(alphabet),
-			err: test.fsErr,
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// set the fs on the pager
+			pager.fs = &mockFile{
+				content: []byte(numbers),
+				err:     test.fsError,
+			}
 
-		output, err := pager.Get(test.pageNumber)
+			output, err := pager.Get(test.pageNumber)
+			if test.returnsError {
+				is.True(err != nil)
+			} else {
+				is.NoErr(err)
+			}
+
+			is.Equal(
+				string(test.expected),
+				string(output),
+			)
+		})
+	}
+}
+
+func TestPagerSet(t *testing.T) {
+	is := is.New(t)
+
+	tests := []struct {
+		name         string
+		pageNumber   int
+		content      []byte
+		expected     []byte
+		fsError      error
+		returnsError bool
+	}{
+		{
+			name:       "write zeroth page",
+			pageNumber: 0,
+			content:    []byte("ab"),
+			expected:   []byte("01ab456789"),
+		},
+		{
+			name:       "write second page",
+			pageNumber: 2,
+			content:    []byte("cd"),
+			expected:   []byte("012345cd89"),
+		},
+
+		// errors
+		{
+			name:         "write second page with fs error",
+			pageNumber:   2,
+			fsError:      errors.New("error"),
+			returnsError: true,
+		},
+		{
+			name:         "write negative page",
+			pageNumber:   -2,
+			returnsError: true,
+		},
+		{
+			name:         "write past freelist",
+			pageNumber:   4,
+			returnsError: true,
+		},
+		{
+			name:         "write page at freelist start",
+			pageNumber:   3,
+			returnsError: true,
+		},
+		{
+			name:         "write with content larger than page size",
+			pageNumber:   0,
+			returnsError: true,
+			content:      []byte("abc"),
+		},
+		{
+			name:         "write with content smaller than page size",
+			pageNumber:   0,
+			returnsError: true,
+			content:      []byte("a"),
+		},
+	}
+
+	pager := Pager{
+		pageSize:      2,
+		freelistIndex: 3,
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// set the fs on the pager
+			m := &mockFile{
+				content: []byte(numbers),
+				err:     test.fsError,
+			}
+			pager.fs = m
+
+			err := pager.Set(test.pageNumber, test.content)
+			if test.returnsError {
+				is.True(err != nil)
+			} else {
+				is.NoErr(err)
+				is.Equal(
+					string(test.expected),
+					string(m.content),
+				)
+			}
+
+		})
 	}
 }

--- a/internal/backend/pager/pager_test.go
+++ b/internal/backend/pager/pager_test.go
@@ -1,0 +1,50 @@
+package pager
+
+import "testing"
+
+type mockFile struct {
+	index   int
+	content []bytes
+	err     error
+}
+
+func (m mockFile) Read(int) ([]byte, error) {
+	return m.content, m.err
+}
+func (m mockFile) Write(int, []content) error {
+	return m.err
+
+}
+func (m mockFile) Size() (int, error) {
+	return m.size, m.err
+}
+
+const (
+	testPageSize = 2
+	alphabet     = "abcdefghijklmnopqrstuvwxyz"
+)
+
+func TestPagerGet(t *testing.T) {
+	tests := []struct {
+		pageNumber int
+		expected   []byte
+		fsErr      error
+		errors     bool
+	}{
+		{0, []byte("cd"), nil, false},
+	}
+
+	pager := Pager{
+		pageSize: 2,
+	}
+
+	for _, test := tests {
+		// set the fs on the pager
+		pager.fs = mockFile{
+			content: []byte(alphabet),
+			err: test.fsErr,
+		}
+
+		output, err := pager.Get(test.pageNumber)
+	}
+}


### PR DESCRIPTION
The *Pager* is the interface through which the B-Tree will fetch and write data pages from the database file.

The following properties exist on the *Pager*:
 - *pageSize*: the block size that the OS uses to interface with files on disk
 - *fs*: a file interface which can be mock, Unix, or Windows implementation
 - *freelistIndex*: the page offset of the first free page in the database

_Rules_:
 * The first page of the database is ALWAYS a header page for metadata information.
 * The following pages for now will be allocated pages by the B-Tree.
 * After the allocated B-Tree pages will be the freelist until the end of the database file.

Work to be addressed:
 - [ ] Allow for resizing the database file when the freelist is exhausted.
 - [ ] Allow for writing to pages on the freelist.
 - [ ] Allow for reading/writing the header page.
 - [ ] Add lock pages and journals for ACID compliance.

Documentation on the data format on the file system can be found here:
https://www.sqlite.org/fileformat2.html
Refer to section 1.2 to learn more about the database pages.