### PR TITLE
BTree: Node serialization functions

### DIFF
--- a/internal/backend/btree/cursor.go
+++ b/internal/backend/btree/cursor.go
@@ -1,0 +1,17 @@
+package btree
+
+type Cursor struct {
+	Node
+}
+
+func (c *Cursor) Search(key uint32) (interface{}, error) {
+	return nil, nil
+}
+
+func (c *Cursor) Insert(key uint32, value interface{}) error {
+	return nil
+}
+
+func (c *Cursor) Delete(key uint32) error {
+	return nil
+}

--- a/internal/backend/btree/node.go
+++ b/internal/backend/btree/node.go
@@ -94,13 +94,16 @@ func (n *Node) MarshalBinary() ([]byte, error) {
 	numCellsBytes := make([]byte, 2)
 	binary.LittleEndian.PutUint16(numCellsBytes, numCells16)
 	data = append(data, numCellsBytes...)
+
 	// append the right pointer
 	rightPointerBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(rightPointerBytes, n.rightPointer)
 	data = append(data, rightPointerBytes...)
+
 	// append the empty header byte
 	data = append(data, 0)
 
+	// add the cells
 	for _, cell := range n.cells {
 		keyBytes := make([]byte, 4)
 		pointerBytes := make([]byte, 4)

--- a/internal/backend/btree/node.go
+++ b/internal/backend/btree/node.go
@@ -1,0 +1,127 @@
+package btree
+
+import "fmt"
+
+type pager interface {
+	PageSize() int
+}
+
+/*
+	Node is the BTree logical implementation
+
+	order: btree order which is the same number of pointers
+	       in the node and the number of keys plus one
+	cells: key pointer pairs ordered by the key value
+*/
+type Node struct {
+	NodeType
+	Order int
+	Cells []cell
+	Pager pager
+}
+
+/*
+	UnmarshalBinary reads in a page and attempts to return a typed
+	Node object. It accomplishes by doing the following things.
+
+	1. Read the node header (8 or 12 bytes).
+	2. Set the node type
+	4. Set the order based on page size
+	3. Read the cells
+	4. Set the page size for when the node needs to be serialized
+*/
+func (n *Node) UnmarshalBinary(data []byte) error {
+	if len(data) < 6 {
+		return fmt.Errorf(
+			"Unexpected length of Node page: %d",
+			len(data),
+		)
+	}
+
+	n.pageSize = len(data)
+
+	/*
+		nodeHeader
+		0:   node type
+		1-2: numCells
+		3-6: rightmost pointer
+		7:   unused
+	*/
+	nodeHeader := data[:8]
+	n.nodeType = nodeType(nodeHeader[0])
+	numCells := int16(nodeHeader[1:3])
+	n.rightPointer = int32(nodeHeader[3:7])
+
+	if n.nodeType != interior && n.nodeType != leaf {
+		return fmt.Errorf("Unknown node type: %d", n.nodeType)
+	}
+
+	n.cells = make([]cell, 0, numCells)
+
+	for i := 0; i < numCells; i++ {
+		// Read cells in 8 byte increments
+		offset := (i * 8) + 8
+		cellBytes := data[offset : offset+8]
+
+		n.cells[i] = cell{
+			key:     int32(cellBytes[:4]),
+			pointer: int32(cellBytes[4:8]),
+		}
+	}
+
+	// order is the number of pointers which is equal to
+	// the number of cells plus 1
+	n.order = ((data - 8) / 8) + 1
+}
+
+/*
+	MarshalBinary performs the opposite action of UnmarshalBinary
+*/
+func (n *Node) MarshalBinary() ([]byte, error) {
+	data := make([]byte, 0, n.pageSize)
+	data = append(data, n.nodeType)
+
+	numCells := int16(len(n.cells))
+	// append the numCells bytes
+	data = append(data, []byte(numCells)...)
+	// append the right pointer
+	data = append(data, []byte(n.rightPointer)...)
+	// append the empty header byte
+	data = append(data, 0)
+
+	for _, cell := range n.cells {
+		data = append(data, []byte(cell.key)...)
+		data = append(data, []byte(cell.pointer)...)
+	}
+
+	// fill the remaining space
+	data = append(
+		data,
+		make([]byte, cap(data)-len(data)),
+	)
+}
+
+/*
+	nodeType describes whether a node is a leaf or not
+*/
+type nodeType byte
+
+const (
+	interior nodeType = 1
+	leaf
+)
+
+/*
+	cell is a key pointer pair in a btree node
+
+	key: corresponds to a value for comparison
+	pointer: left pointer for the key. all children's keys will
+	         be less than or equal to the key value
+
+
+	serialized it is laid out on disk [key, pointer]
+*/
+type cell struct {
+	key     int32
+	pointer int32
+}

--- a/internal/backend/btree/node_test.go
+++ b/internal/backend/btree/node_test.go
@@ -1,24 +1,77 @@
 package btree
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/matryer/is"
+)
 
 func TestSerialization(t *testing.T) {
 	is := is.New(t)
 
 	tests := []struct {
-		name string
-		node *Node
+		name     string
+		node     *Node
+		notEqual bool
+		errors   bool
 	}{
-		name: "simple test",
-		node: &Node{
-			n.nodeType: interior,
-			n.pageSize: 32,
-			n.order:    3,
-			n.cells: []cell{
-				{1, 2},
-				{3, 4},
-				{5, 6},
+		{
+			name: "simple test",
+			node: &Node{
+				nodeType: interior,
+				pageSize: 32,
+				order:    4,
+				cells: []cell{
+					{1, 2},
+					{3, 4},
+					{5, 6},
+				},
 			},
+		},
+		{
+			name: "empty node",
+			node: &Node{
+				nodeType: leaf,
+				pageSize: 32,
+				order:    4,
+				cells:    []cell{},
+			},
+		},
+		{
+			name: "obscure page size",
+			node: &Node{
+				nodeType: leaf,
+				pageSize: 37,
+				order:    4,
+				cells:    []cell{},
+			},
+		},
+
+		// not equal
+		{
+			name: "unrealistic order",
+			node: &Node{
+				nodeType: interior,
+				pageSize: 32,
+				order:    6,
+				cells:    []cell{},
+			},
+			notEqual: true,
+		},
+
+		// errors
+		{
+			name: "invalid node type",
+			node: &Node{
+				nodeType: nodeType(0),
+				pageSize: 32,
+				order:    4,
+				cells:    []cell{},
+			},
+			errors:   true,
+			notEqual: true,
 		},
 	}
 
@@ -29,9 +82,26 @@ func TestSerialization(t *testing.T) {
 			is.NoErr(err)
 
 			newNode := &Node{}
-			newNode.UnmarshalBinary(b)
+			err = newNode.UnmarshalBinary(b)
 
-			is.Equal(test.node, newNode)
+			if test.errors {
+				is.True(err != nil)
+			} else {
+				is.NoErr(err)
+			}
+			isEqual := reflect.DeepEqual(test.node, newNode)
+
+			if test.notEqual == isEqual {
+				b1, _ := json.Marshal(test.node)
+				b2, _ := json.Marshal(newNode)
+
+				t.Fatalf(
+					"Expected equality: %t\ninput:%s\noutput:%s",
+					!test.notEqual,
+					b1,
+					b2,
+				)
+			}
 		})
 
 	}

--- a/internal/backend/btree/node_test.go
+++ b/internal/backend/btree/node_test.go
@@ -1,0 +1,38 @@
+package btree
+
+import "testing"
+
+func TestSerialization(t *testing.T) {
+	is := is.New(t)
+
+	tests := []struct {
+		name string
+		node *Node
+	}{
+		name: "simple test",
+		node: &Node{
+			n.nodeType: interior,
+			n.pageSize: 32,
+			n.order:    3,
+			n.cells: []cell{
+				{1, 2},
+				{3, 4},
+				{5, 6},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := test.node.MarshalBinary()
+
+			is.NoErr(err)
+
+			newNode := &Node{}
+			newNode.UnmarshalBinary(b)
+
+			is.Equal(test.node, newNode)
+		})
+
+	}
+}


### PR DESCRIPTION
This PR implements the `Node` struct which will serve *strictly* as a data structure within the popsql codebase.

See https://www.sqlite.org/fileformat2.html section 1.6 to understand the sqlite btree node implementation and serialization format.

One very notable divergence from the sqlite implementation is that there is only one type of btree node (as opposed to sqlite's 4). The reason for this is simplicity in use and development.

Work to be addressed:
 - [ ] Swap in keys that aren't strictly `uints` (will be trickier because of size variance).